### PR TITLE
Add void visitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,3 @@ public partial class Failure
 ## Using the package
 
 The package is published here on github. Please follow the documentation to add the nuget source https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry
-
-## Improvements
-
-- `void` visitor interface
-- `Task` visitor interface
-- `Task<T>` visitor interface
-- publish to nuget.org
-- tests!

--- a/VisitorGenerator.Samples/Program.cs
+++ b/VisitorGenerator.Samples/Program.cs
@@ -13,6 +13,63 @@ internal class Program
     }
 }
 
+public class Visitor2 : OpResultVisitor<Task>
+{
+    public Task Visit(Node node)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task Visit(Success node)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task Visit(Failure node)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task Visit(InvalidOperation node)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task Visit(NoOperation node)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class AsyncVisitor : OpResultVisitor<Task<int>>
+{
+    public async Task<int> Visit(Node node)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int> Visit(Success node)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int> Visit(Failure node)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int> Visit(InvalidOperation node)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int> Visit(NoOperation node)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+
 public class Visitor : OpResultVisitor<bool>
 {
     public bool Visit(Success node)


### PR DESCRIPTION
Close #2 

There is no need for `Task` or `Task<T>` dedicated interfaces since the `T` can be anything including `Task` or `Task<T>`.